### PR TITLE
Don't set window.Promise with API-incompatible CancellablePromise.

### DIFF
--- a/src/promise/Promise.js
+++ b/src/promise/Promise.js
@@ -1178,8 +1178,4 @@ CancellablePromise.CancellationError = class extends Error {
 /** @override */
 CancellablePromise.CancellationError.prototype.name = 'cancel';
 
-if (typeof window.Promise === 'undefined') {
-  window.Promise = CancellablePromise;
-}
-
 export {CancellablePromise, async};


### PR DESCRIPTION
Closure's CancellablePromise and ES6 Promise have slightly different APIs and this behavior, besides not being consistent, can lead to errors / unexpected results.