### PR TITLE
Ensure that progress listeners added to child promises are called

### DIFF
--- a/__tests__/ProgressPromise.js
+++ b/__tests__/ProgressPromise.js
@@ -105,4 +105,25 @@ describe('ProgressPromise', function() {
 			done();
 		})
 	});
+
+	test('promise should call all progress listeners of child promises', function(done) {
+		const listener = sinon.stub();
+
+		const promise = new ProgressPromise(function(resolve, reject, progress) {
+			async.nextTick(() => {
+				progress(0.5);
+				progress(0.75);
+				resolve();
+			});
+		})
+		.thenCatch(function() {})
+		.progress(listener)
+		.then(() => {
+			expect(listener.callCount).toBe(2);
+			expect(listener.getCall(0).args[0]).toBe(0.5);
+			expect(listener.getCall(1).args[0]).toBe(0.75);
+
+			done();
+		})
+	});
 });

--- a/src/ProgressPromise.js
+++ b/src/ProgressPromise.js
@@ -27,13 +27,66 @@ class ProgressPromise extends CancellablePromise {
 	}
 
 	/**
-	 * Invokes any listeners that have been attached via the progress` method.
+	 * Overwrites `CancellablePromise.prototype.addChildPromise_` so that it
+	 * implements another `ProgressPromise` as a child.
+	 * @inheritdoc
 	 */
-	callProgressListeners_() {
-		const progress = this.progress_;
+	addChildPromise_(onFulfilled, onRejected, opt_context) {
+		var callbackEntry = {
+			child: null,
+			onFulfilled: null,
+			onRejected: null
+		};
 
-		if (this.listeners_.length) {
-			this.listeners_.forEach(listener => {
+		callbackEntry.child = new ProgressPromise(function(resolve, reject) {
+			callbackEntry.onFulfilled = onFulfilled ? function(value) {
+				try {
+					var result = onFulfilled.call(opt_context, value);
+					resolve(result);
+				} catch (err) {
+					reject(err);
+				}
+			} : resolve;
+
+			callbackEntry.onRejected = onRejected ? function(reason) {
+				try {
+					var result = onRejected.call(opt_context, reason);
+					if (!isDef(result) && reason.IS_CANCELLATION_ERROR) {
+						reject(reason);
+					} else {
+						resolve(result);
+					}
+				} catch (err) {
+					reject(err);
+				}
+			} : reject;
+		});
+
+		callbackEntry.child.parent_ = this;
+		this.addCallbackEntry_(callbackEntry);
+		return callbackEntry.child;
+	}
+
+	/**
+	 * Invokes any listeners that have been attached to child promises.
+	 * @param {!number} progress A percentage between 0 and 1
+	 */
+	callChildProgressListeners_(progress) {
+		if (this.callbackEntries_ && this.callbackEntries_.length) {
+			this.callbackEntries_.forEach(callback => {
+				this.callProgressListeners_(progress, callback.child.listeners_);
+			});
+		}
+	}
+
+	/**
+	 * Invokes any listeners that have been attached via the `progress` method.
+	 * @param {!number} progress A percentage between 0 and 1
+	 * @param {!Array} listeners Array of listeners
+	 */
+	callProgressListeners_(progress, listeners) {
+		if (listeners.length) {
+			listeners.forEach(listener => {
 				listener(progress);
 			});
 		}
@@ -72,7 +125,9 @@ class ProgressPromise extends CancellablePromise {
 		}
 
 		this.progress_ = progress;
-		this.callProgressListeners_();
+
+		this.callProgressListeners_(progress, this.listeners_);
+		this.callChildProgressListeners_(progress);
 	}
 }
 


### PR DESCRIPTION
`CancellablePromise` methods such as `catch`, `thenCatch`, and `then` create a child promise. This means that calling `progress()` after one of these methods will fail. This PR ensures that child promises of `ProgressPromise` are also instances of `ProgressPromise`. This will allow the following to work.

```javascript
new ProgressPromise(function(resolve, reject, progress) {
	progress(0.3)
	progress(0.7)
	resolve();
}).thenCatch(function(error) {
  // handle error
}).progress(function(progress) {
  // handle progress
});
```

See https://github.com/metal/metal-ajax/pull/17 for more information.